### PR TITLE
Add gitpod config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@
 CMakeFiles
 CMakeCache.txt
 cmake_install.cmake
+/compile_commands.json
 
 # mechanisms generated from .mod files
 mechanisms/multicore/*.hpp

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ CMakeCache.txt
 cmake_install.cmake
 /compile_commands.json
 
+# install path used in gitpod
+/install
+
 # mechanisms generated from .mod files
 mechanisms/multicore/*.hpp
 mechanisms/gpu/*.hpp

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,16 +1,29 @@
+vscode:
+  extensions:
+    - twxs.cmake@0.0.17:9s7m9CWOr6i6NZ7CNNF4kw==
+    - ms-vscode.cmake-tools@1.3.1:Yde58UUl5J9XpLmXM+Bqiw==
+    - ms-vscode.cpptools@0.26.2:Pq/tmf2WN3SanVzB4xZc1g==
+    - eamodio.gitlens@10.2.1:ZI2Sl3DHdJu4aG2wW92CQQ==
+
 tasks:
   - init: |
-      mkdir build && cd build && cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      git submodule update --init --recursive
+      mkdir build
+      cmake -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -H/workspace/arbor -B/workspace/arbor/build \
+      -DCMAKE_INSTALL_PREFIX:STRING=/workspace/arbor/install -DCMAKE_BUILD_TYPE:STRING=Debug -G "Unix Makefiles" \
+      -DARB_WITH_PYTHON:BOOL=ON
       ln -s $(pwd)/compile_commands.json /workspace/arbor
     prebuild: |
       make -j$(nproc)
+      # make -j$(nproc) tests
+      # ./build/bin/unit
 
 github:
   prebuilds:
     # enable for the master/default branch (defaults to true)
     master: true
     # enable for all branches in this repo (defaults to false)
-    branches: true
+    branches: false
     # enable for pull requests coming from this repo (defaults to true)
     pullRequests: true
     # enable for pull requests coming from forks (defaults to false)
@@ -18,8 +31,8 @@ github:
     # add a check to pull requests (defaults to true)
     addCheck: true
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
-    addComment: true
+    addComment: false
     # add a "Review in Gitpod" button to the pull request's description (defaults to false)
-    addBadge: true
+    addBadge: false
     # add a label once the prebuild is ready to pull requests (defaults to false)
-    addLabel: true
+    addLabel: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,7 +12,7 @@ tasks:
       cmake -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -H/workspace/arbor -B/workspace/arbor/build \
       -DCMAKE_INSTALL_PREFIX:STRING=/workspace/arbor/install -DCMAKE_BUILD_TYPE:STRING=Debug -G "Unix Makefiles" \
       -DARB_WITH_PYTHON:BOOL=ON
-      ln -s $(pwd)/compile_commands.json /workspace/arbor
+      ln -s /workspace/arbor/build/compile_commands.json /workspace/arbor
     prebuild: |
       make -j$(nproc)
       # make -j$(nproc) tests

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,4 +2,24 @@ tasks:
   - init: |
       mkdir build && cd build && cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       ln -s $(pwd)/compile_commands.json /workspace/arbor
-      
+    prebuild: |
+      make -j$(nproc)
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,9 +14,7 @@ tasks:
       -DARB_WITH_PYTHON:BOOL=ON
       ln -s /workspace/arbor/build/compile_commands.json /workspace/arbor
     prebuild: |
-      make -j$(nproc)
-      # make -j$(nproc) tests
-      # ./build/bin/unit
+      cmake --build /workspace/arbor/build/ --parallel $(nproc)
 
 github:
   prebuilds:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+tasks:
+  - init: |
+      mkdir build && cd build && cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      ln -s $(pwd)/compile_commands.json /workspace/arbor
+      

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,8 +13,9 @@ tasks:
       -DCMAKE_INSTALL_PREFIX:STRING=/workspace/arbor/install -DCMAKE_BUILD_TYPE:STRING=Debug -G "Unix Makefiles" \
       -DARB_WITH_PYTHON:BOOL=ON
       ln -s /workspace/arbor/build/compile_commands.json /workspace/arbor
+      export PYTHONPATH=/workspace/arbor/install/lib/python3.7/site-packages
     prebuild: |
-      cmake --build /workspace/arbor/build/ --parallel $(nproc)
+      cmake --build /workspace/arbor/build/ --parallel $(nproc) --target install
 
 github:
   prebuilds:

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,5 @@
+{
+    "cpp.clangTidy": true,
+    "cmake.configureOnOpen": true,
+    "C_Cpp.intelliSenseEngine": "Disabled"
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/arbor-sim/arbor) 
+
 # Arbor Library
 
 [![Build Status](https://travis-ci.org/arbor-sim/arbor.svg?branch=master)](https://travis-ci.org/arbor-sim/arbor)

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,1 @@
+/workspace/arbor/build/compile_commands.json

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,1 +1,0 @@
-/workspace/arbor/build/compile_commands.json


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.

<a href="https://gitpod.io/#https://github.com/havogt/arbor/pull/2"><img src="https://gitpod.io/api/apps/github/pbs/github.com/havogt/arbor.git/0a57d79bc1802fa2ae92e545d5c2cab5583f6b9a.svg" /></a>

